### PR TITLE
docs: improve example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ name: Dependency Submission
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: ['main']
   push:
-    branches: ['main']
+    branches: ['main', 'master']
+    paths:
+      - '**/uv.lock'
 
 permissions: {}
 


### PR DESCRIPTION
Include both `main` and `master` branches by default, so that copy/paste is more likely to work. Although the action is fast, running on every PR and every push is not a good default. Run on pushes to main branch when `uv.lock` files change to reduce CI minutes, yet still maintain accurate graph.