### PR TITLE
docs: address new zizmor lints in example and workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
     labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,15 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     name: Run actionlint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -25,6 +30,7 @@ jobs:
   zizmor:
     name: Run zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       security-events: write # integration with github advanced security
     steps:
@@ -40,6 +46,7 @@ jobs:
   lint:
     name: Run python linters
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -56,6 +63,7 @@ jobs:
   submit:
     name: Submit test data
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # needs to submit dependency graph data
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,16 @@ name: CodeQL
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       security-events: write # integrate with Github Advanced Security
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,15 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   github:
     name: Create Github release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # create github release
       id-token: write # deploy

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-submission:
     name: Submit uv dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # needs to submit dependency graph data
     steps:
@@ -36,6 +41,9 @@ jobs:
       - name: Submit dependency snapshot
         uses: rmuir/uv-dependency-submission@1c48aaac13e566e39fd04269ff1900b86c1105c5 # v1.0.0
 ```
+
+> [!NOTE]
+> After adding the workflow, trigger once manually from Actions UI to confirm correct setup.
 
 # Configuration
 Currently there are no parameters.
@@ -53,7 +61,7 @@ Existing alternatives scan the dependencies and may issue many API calls to audi
 - https://github.com/owenlamont/uv-secure
 - https://github.com/nyudenkov/pysentry
 
-This action works differently: it does not audit your packages. 
+This action works differently: it does not audit your packages.
 It will make exactly one API call to publish the graph to Github: you can use Github's security tab to do the rest.
 
 # Caveats


### PR DESCRIPTION
Set a more reasonable timeout than the default of 6 hours. The action usually takes only a few seconds, but if something is wrong, avoid wasting minutes.

Specify concurrency group to cancel previous workflow execution in case of duplication.

Set cooldown period for dependabot.