### PR TITLE
ci: improve python CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,22 @@
 version: 2
 updates:
+  # CI only: action has no dependencies
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+  # CI only: python code has no dependencies
+  - package-ecosystem: uv
+    directory: /
+    exclude-paths:
+      - test/**
     schedule:
       interval: weekly
       day: sunday

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,17 @@ name = "uv-dependency-submission"
 version = "1.0.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = []
 
 [dependency-groups]
 dev = [
-  "ruff",
-  "basedpyright",
+  "ruff==0.13.2",
+  "basedpyright==1.31.6",
 ]
 
 [tool.basedpyright]
-pythonVersion = "3.13"
+pythonVersion = "3.12"
 exclude = [
   "data",
   ".venv"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 
 [[package]]
 name = "basedpyright"
@@ -71,6 +71,6 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedpyright" },
-    { name = "ruff" },
+    { name = "basedpyright", specifier = "==1.31.6" },
+    { name = "ruff", specifier = "==0.13.2" },
 ]


### PR DESCRIPTION
Configure python version to the one configured by the action. Currently this is python 3.12, which is available on the `ubuntu-latest` image without hassles.

Configure dependabot to upgrade the basedpyright and ruff versions used in the CI. It should ignore the uv files in test/ directory, they might be big and nobody wants pull requests against them.

Set basedpyright and ruff versions to the ones in use, to be upgraded by dependabot in PRs.