### PR TITLE
check message for retryable errors too

### DIFF
--- a/action.py
+++ b/action.py
@@ -82,9 +82,15 @@ def retrying_check_output(cmd: list[str], *, input: str) -> str:
             return output
         except subprocess.CalledProcessError as e:
             last_err = e
+            sys.stderr.flush()
             print(e.output)
+            sys.stdout.flush()
             body = json.loads(e.output)
-            if body["status"] not in retryable_statuses:
+            if body.get("message", "") == "Server Error":
+                pass
+            elif body.get("status", "") in retryable_statuses:
+                pass
+            else:
                 raise
 
     print(f"{RED}Command failed, no more retries{END}")

--- a/action.py
+++ b/action.py
@@ -85,6 +85,9 @@ def retrying_check_output(cmd: list[str], *, input: str) -> str:
             sys.stderr.flush()
             print(e.output)
             sys.stdout.flush()
+            # low-level error, no HTTP response json, just fail
+            if len(e.output) == 0:
+                raise
             body = json.loads(e.output)
             if body.get("message", "") == "Server Error":
                 pass


### PR DESCRIPTION
First of all: thanks for the awesome work with reviewing, merging, releasing, etc :-)

I ~finally~ got another 502 and turns out that `gh api` doesn't print status in that case. Or at least it looks like it doesn't, because the logs get interspersed.

So this PR does two things: uses the field which seems to be there and calls some .flush() methods to prevent interspersed logs.

The logs contain `{ "message": "Server Error" }`, so let's use that even though it seems a bit silly.